### PR TITLE
feat: upgrade browserify-zlib

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "browserify-zlib": "^0.1.4",
+    "browserify-zlib": "^0.2.0",
     "is-deflate": "^1.0.0",
     "is-gzip": "^1.0.0",
     "peek-stream": "^1.1.0",


### PR DESCRIPTION
It's unclear where the "major" version bump came from, they do have a
number of changes, but they seem mostly to be changing test framework,
upgrading dependencies (I care about the transitive `pako` upgrade), and
the like. The project is kinda quiet.

Note that the 1.0 release is of a different, temporary name, while the
PR below was trying to merge. It merged in 2017, and they released it,
as 0.2, instead of as 1.0.

https://github.com/browserify/browserify-zlib/commits/master
https://github.com/browserify/browserify-zlib/pull/18